### PR TITLE
Create .env file and use it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+## .gitignore
+
+.env

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,21 @@
 
-build:
+.env:
+	case "$$(uname -s)" in \
+	  Linux*)   echo PYGAME_DISPLAY="$$DISPLAY" > $@;; \
+	  Darwin*)  echo PYGAME_DISPLAY="host.docker.internal:0" > $@;; \
+	  CYGWIN*)  echo PYGAME_DISPLAY="host.docker.internal:0" > $@;; \
+	  MINGW*)   echo PYGAME_DISPLAY="host.docker.internal:0" > $@;; \
+	  *)        echo "UNKNOWN uname output:$$(uname -s)";; \
+	esac
+
+build: .env
 	docker-compose build
 
-up:
+up: .env
 	docker-compose up -d
 
-exec:
+exec: .env
 	docker-compose exec app bash
 
-down:
+down: .env
 	docker-compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   app:
     build: ./
     tty: true
+    env_file:
+      - ./.env
     environment:
       - DISPLAY=${PYGAME_DISPLAY}
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
 version: '3'
 services:
-    app:
-        build: ./
-        tty: true
-        environment:
-            - DISPLAY=${DISPLAY}
-        volumes:
-            - /tmp/.X11-unix:/tmp/.X11-unix
-            - ./:/home/docker/app
+  app:
+    build: ./
+    tty: true
+    environment:
+      - DISPLAY=${PYGAME_DISPLAY}
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix
+      - ./:/home/docker/app


### PR DESCRIPTION
Docker-compose.yml内でOS分岐する方法がなかったので、とりあえず.envファイルを動的に作って読む方法を採用しました。

host.docker.internalはMac/Windowsのみ使えるようです。
Ref: [qiita](https://qiita.com/ijufumi/items/badde64d530e6bade382#%E3%81%9D%E3%81%AE5hostdockerinternal-%E3%82%92%E4%BD%BF%E3%81%86-20190916%E8%BF%BD%E8%A8%9820200227%E7%B7%A8%E9%9B%86)

ただ、Windowsでは動作確認してません。